### PR TITLE
Kotlin extension functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <!-- code is executed using this version of Java -->
         <maven.compiler.target>1.8</maven.compiler.target>
+        <kotlin.version>1.8.10</kotlin.version>
     </properties>
 
     <licenses>
@@ -54,15 +55,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
-                <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -175,6 +167,56 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
             </plugin>
+            <!--            Kotlin-->
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmTarget>${maven.compiler.target}</jvmTarget>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -204,6 +246,17 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/kotlin/KAnsi.kt
+++ b/src/main/kotlin/KAnsi.kt
@@ -1,0 +1,8 @@
+import com.diogonunes.jcolor.*
+
+fun Command.colorize(): String = Ansi.colorize(this)
+
+infix fun String.colorize(ansiCode: String): String = Ansi.colorize(this, ansiCode)
+infix fun String.colorize(attributes: AnsiFormat): String = Ansi.colorize(this, attributes)
+fun String.colorize(vararg attributes: Attribute): String = Ansi.colorize(this, *attributes)
+infix fun String.colorize(attributes: Collection<Attribute>): String = Ansi.colorize(this, *attributes.toTypedArray())

--- a/src/main/kotlin/com/diogonunes/jcolor/KAnsi.kt
+++ b/src/main/kotlin/com/diogonunes/jcolor/KAnsi.kt
@@ -1,4 +1,4 @@
-import com.diogonunes.jcolor.*
+package com.diogonunes.jcolor
 
 fun Command.colorize(): String = Ansi.colorize(this)
 


### PR DESCRIPTION
Hey! I added some extension functions to make JColor more convenient to use in Kotlin. Let me know if you would like to integrate them to JColor (I'll take care of tests & docs), or perhaps I should just keep them as a fork.

Usage:
```
val kotlinFormat = AnsiFormat(Attribute.RED_TEXT(), Attribute.WHITE_BACK())

println("infix notation..." colorize kotlinFormat)

println("...or as an extension of String".colorize(Attribute.BLUE_BACK()))
```